### PR TITLE
Adapt `FieldBatch` struct for GPUs

### DIFF
--- a/src/BoundaryConditions/BoundaryConditions.jl
+++ b/src/BoundaryConditions/BoundaryConditions.jl
@@ -13,6 +13,7 @@ using Chmy.Architectures
 import Chmy: @add_cartesian
 
 using KernelAbstractions
+using Adapt
 
 import Base.@propagate_inbounds
 

--- a/src/BoundaryConditions/batch.jl
+++ b/src/BoundaryConditions/batch.jl
@@ -44,7 +44,7 @@ struct FieldBatch{K,F,B} <: AbstractBatch
 end
 
 # adapt to GPU
-Adapt.adapt_structure(to, fb::FieldBatch{K}) where {K} = FieldBatch{K}(Adapt.adapt(to, fb.fields), fb.conditions)
+Adapt.adapt_structure(to, fb::FieldBatch{K}) where {K} = FieldBatch(Adapt.adapt(to, fb.fields), fb.conditions)
 
 regularise(::StructuredGrid{N}, bc::FieldBoundaryCondition) where {N} = ntuple(_ -> (bc, bc), N)
 

--- a/src/BoundaryConditions/batch.jl
+++ b/src/BoundaryConditions/batch.jl
@@ -43,6 +43,9 @@ struct FieldBatch{K,F,B} <: AbstractBatch
     end
 end
 
+# adapt to GPU
+Adapt.adapt_structure(to, fb::FieldBatch{K}) where {K} = FieldBatch{K}(Adapt.adapt(to, fb.field), fb.condition)
+
 regularise(::StructuredGrid{N}, bc::FieldBoundaryCondition) where {N} = ntuple(_ -> (bc, bc), N)
 
 default_bcs(grid::StructuredGrid) = NamedTuple{axes_names(grid)}(ntuple(_ -> (nothing, nothing), Val(ndims(grid))))

--- a/src/BoundaryConditions/batch.jl
+++ b/src/BoundaryConditions/batch.jl
@@ -44,7 +44,7 @@ struct FieldBatch{K,F,B} <: AbstractBatch
 end
 
 # adapt to GPU
-Adapt.adapt_structure(to, fb::FieldBatch{K}) where {K} = FieldBatch{K}(Adapt.adapt(to, fb.field), fb.condition)
+Adapt.adapt_structure(to, fb::FieldBatch{K}) where {K} = FieldBatch{K}(Adapt.adapt(to, fb.fields), fb.conditions)
 
 regularise(::StructuredGrid{N}, bc::FieldBoundaryCondition) where {N} = ntuple(_ -> (bc, bc), N)
 

--- a/src/Fields/field.jl
+++ b/src/Fields/field.jl
@@ -15,12 +15,7 @@ Base.@assume_effects :foldable halo(::Field{T,N,A,H}) where {T,N,A,H} = H
 Base.size(f::Field) = f.dims
 Base.parent(f::Field) = f.data
 
-# @propagate_inbounds Base.getindex(f::Field{T,N,L,H}, I::Vararg{Int,N}) where {T,N,L,H} = f.data[(I .+ 2 .* H)...]
-
-@propagate_inbounds function Base.getindex(f::Field{T,N,L,H}, I::Vararg{Int,N}) where {T,N,L,H}
-    indices = I .+ 2 .* H
-    view(f.data, indices...)
-end
+@propagate_inbounds Base.getindex(f::Field{T,N,L,H}, I::Vararg{Int,N}) where {T,N,L,H} = f.data[(I .+ 2 .* H)...]
 
 @propagate_inbounds function Base.setindex!(f::Field{T,N,L,H}, v, I::Vararg{Int,N}) where {T,N,L,H}
     f.data[(I .+ 2 .* H)...] = v

--- a/src/Fields/field.jl
+++ b/src/Fields/field.jl
@@ -15,7 +15,12 @@ Base.@assume_effects :foldable halo(::Field{T,N,A,H}) where {T,N,A,H} = H
 Base.size(f::Field) = f.dims
 Base.parent(f::Field) = f.data
 
-@propagate_inbounds Base.getindex(f::Field{T,N,L,H}, I::Vararg{Int,N}) where {T,N,L,H} = f.data[(I .+ 2 .* H)...]
+# @propagate_inbounds Base.getindex(f::Field{T,N,L,H}, I::Vararg{Int,N}) where {T,N,L,H} = f.data[(I .+ 2 .* H)...]
+
+@propagate_inbounds function Base.getindex(f::Field{T,N,L,H}, I::Vararg{Int,N}) where {T,N,L,H}
+    indices = I .+ 2 .* H
+    view(f.data, indices...)
+end
 
 @propagate_inbounds function Base.setindex!(f::Field{T,N,L,H}, v, I::Vararg{Int,N}) where {T,N,L,H}
     f.data[(I .+ 2 .* H)...] = v


### PR DESCRIPTION
This PR adds an `Adapt` method to allow `FieldBatch` to work with GPU kernels.