### PR TITLE
Retrieve arch props

### DIFF
--- a/src/Architectures.jl
+++ b/src/Architectures.jl
@@ -27,6 +27,8 @@ struct SingleDeviceArchitecture{B,D} <: Architecture
     end
 end
 
+SingleDeviceArchitecture(arch::Architecture) = SingleDeviceArchitecture(get_backend(arch), get_device(arch))
+
 """
     Arch(backend::Backend; device_id::Integer=1)
 


### PR DESCRIPTION
This PR adds a method in order to automatically retrieve backend and device from another Architecture, including from Distributed.