### PR TITLE
Add masked operators

### DIFF
--- a/.buildkite/run_tests.yml
+++ b/.buildkite/run_tests.yml
@@ -46,7 +46,7 @@ steps:
     agents:
       queue: "juliagpu"
       rocm: "*"
-      rocmgpu: "gfx1101" # select Ludovic's Navi 3 card (ROCm 6.0)
+      rocmgpu: "*" #"gfx1101" # select Ludovic's Navi 3 card (ROCm 6.0)
     timeout_in_minutes: 120
     soft_fail:
       - exit_status: 3

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Chmy"
 uuid = "33a72cf0-4690-46d7-b987-06506c2248b9"
 authors = ["Ivan Utkin <iutkin@ethz.ch>, Ludovic Raess <ludovic.rass@gmail.com>, and contributors"]
-version = "0.1.10"
+version = "0.1.11"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Chmy"
 uuid = "33a72cf0-4690-46d7-b987-06506c2248b9"
 authors = ["Ivan Utkin <iutkin@ethz.ch>, Ludovic Raess <ludovic.rass@gmail.com>, and contributors"]
-version = "0.1.11"
+version = "0.1.12"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"

--- a/src/BoundaryConditions/batch.jl
+++ b/src/BoundaryConditions/batch.jl
@@ -172,7 +172,7 @@ bc!(arch::Architecture, grid::SG, f_bc::Vararg{FieldAndBC}; kwargs...) = bc!(arc
 end
 
 function bc!(side::Side, dim::Dim, arch::Architecture, grid::SG, batch::FieldBatch)
-    worksize = remove_dim(dim, size(grid, Center()) .+ 2)
+    worksize = remove_dim(dim, size(grid, Vertex()) .+ 2)
     bc_kernel!(Architectures.get_backend(arch), 256, worksize)(side, dim, grid, batch.fields, batch.conditions)
     return
 end

--- a/src/Chmy.jl
+++ b/src/Chmy.jl
@@ -6,6 +6,8 @@ using KernelAbstractions
 export Dim, Side, Left, Right
 export remove_dim, insert_dim
 
+export Offset
+
 include("macros.jl")
 include("utils.jl")
 

--- a/src/Fields/field.jl
+++ b/src/Fields/field.jl
@@ -9,7 +9,7 @@ struct Field{T,N,L,H,A} <: AbstractField{T,N,L}
     Field{L,H}(data::AbstractArray{T,N}, dims::NTuple{N,Integer}) where {L,H,T,N} = new{T,N,L,H,typeof(data)}(data, dims)
 end
 
-Base.@assume_effects :foldable halo(::Field{T,N,A,H}) where {T,N,A,H} = H
+halo(::Field{T,N,A,H}) where {T,N,A,H} = H
 
 # AbstractArray interface
 Base.size(f::Field) = f.dims

--- a/src/GridOperators/GridOperators.jl
+++ b/src/GridOperators/GridOperators.jl
@@ -7,9 +7,12 @@ export itp, lerp, hlerp
 
 export divg
 
+export AbstractMask, FieldMask, FieldMask1D, FieldMask2D, FieldMask3D, at
+
 using Chmy
 using Chmy.Grids
 using Chmy.Fields
+using Chmy.Architectures
 
 import Chmy.@add_cartesian
 
@@ -33,5 +36,11 @@ m(::Dim{D}, I::Vararg{Integer,N}) where {D,N} = ntuple(i -> i == D ? I[i] - oneu
 include("partial_derivatives.jl")
 include("interpolation.jl")
 include("field_operators.jl")
+include("cartesian_field_operators.jl")
+
+include("masked_operators.jl")
+include("field_mask.jl")
+include("masked_field_operators.jl")
+include("masked_cartesian_field_operators.jl")
 
 end

--- a/src/GridOperators/GridOperators.jl
+++ b/src/GridOperators/GridOperators.jl
@@ -16,6 +16,8 @@ using Chmy.Architectures
 
 import Chmy.@add_cartesian
 
+using Adapt
+
 import Base: @propagate_inbounds, front
 
 p(::Dim{D}, I::Vararg{Integer,N}) where {D,N} = ntuple(i -> i == D ? I[i] + oneunit(I[i]) : I[i], Val(N))

--- a/src/GridOperators/GridOperators.jl
+++ b/src/GridOperators/GridOperators.jl
@@ -32,8 +32,10 @@ m(::Dim{D}, I::Vararg{Integer,N}) where {D,N} = ntuple(i -> i == D ? I[i] - oneu
 @add_cartesian il(loc::L, from::L, dim, I::Vararg{Integer,N}) where {N,L<:Location} = m(dim, I...)
 @add_cartesian ir(loc::L, from::L, dim, I::Vararg{Integer,N}) where {N,L<:Location} = p(dim, I...)
 
-@add_cartesian left(f, loc, from, dim, I::Vararg{Integer,N}) where {N} = f[il(loc, from, dim, I...)...]
-@add_cartesian right(f, loc, from, dim, I::Vararg{Integer,N}) where {N} = f[ir(loc, from, dim, I...)...]
+@add_cartesian left(f, loc::NTuple{N,Location}, from::NTuple{N,Location}, dim::Dim{D}, I::Vararg{Integer,N}) where {N,D} = f[il(loc[D], from[D], dim, I...)...]
+@add_cartesian right(f, loc::NTuple{N,Location}, from::NTuple{N,Location}, dim::Dim{D}, I::Vararg{Integer,N}) where {N,D} = f[ir(loc[D], from[D], dim, I...)...]
+
+flipped(loc::NTuple{N,Location}, ::Dim{D}) where {N,D} = ntuple(dim -> dim == D ? flip(loc[dim]) : loc[dim], Val(N))
 
 include("partial_derivatives.jl")
 include("interpolation.jl")

--- a/src/GridOperators/cartesian_field_operators.jl
+++ b/src/GridOperators/cartesian_field_operators.jl
@@ -1,0 +1,46 @@
+for (dim, coord) in enumerate((:x, :y, :z))
+    _l = Symbol(:left, coord)
+    _r = Symbol(:right, coord)
+    _δ = Symbol(:δ, coord)
+    _∂ = Symbol(:∂, coord)
+
+    @eval begin
+        export $_δ, $_∂, $_l, $_r
+
+        """
+            $($_l)(f, I)
+
+        "left side" of a field (`[1:end-1]`) in $($(string(coord))) direction.
+        """
+        @add_cartesian function $_l(f::AbstractField, I::Vararg{Integer,N}) where {N}
+            left(f, Dim($dim), I...)
+        end
+
+        """
+            $($_r)(f, I)
+
+        "right side" of a field (`[2:end]`) in $($(string(coord))) direction.
+        """
+        @add_cartesian function $_r(f::AbstractField, I::Vararg{Integer,N}) where {N}
+            right(f, Dim($dim), I...)
+        end
+
+        """
+            $($_δ)(f, I)
+
+        Finite difference in $($(string(coord))) direction.
+        """
+        @add_cartesian function $_δ(f::AbstractField, I::Vararg{Integer,N}) where {N}
+            δ(f, Dim($dim), I...)
+        end
+
+        """
+            $($_∂)(f, grid, I)
+
+        Directional partial derivative in $($(string(coord))) direction.
+        """
+        @add_cartesian function $_∂(f::AbstractField, grid, I::Vararg{Integer,N}) where {N}
+            ∂(f, grid, Dim($dim), I...)
+        end
+    end
+end

--- a/src/GridOperators/field_mask.jl
+++ b/src/GridOperators/field_mask.jl
@@ -91,3 +91,23 @@ end
 FieldMask(arch::Architecture, grid::StructuredGrid{1}, args...; kwargs...) = FieldMask1D(arch, grid, args...; kwargs...)
 FieldMask(arch::Architecture, grid::StructuredGrid{2}, args...; kwargs...) = FieldMask2D(arch, grid, args...; kwargs...)
 FieldMask(arch::Architecture, grid::StructuredGrid{3}, args...; kwargs...) = FieldMask3D(arch, grid, args...; kwargs...)
+
+# Adapt rules
+
+Adapt.adapt_structure(to, f::FieldMask1D{T}) where {T} = FieldMask1D{T}(Adapt.adapt(to, f.c), Adapt.adapt(to, f.v))
+
+function Adapt.adapt_structure(to, f::FieldMask2D{T}) where {T}
+    FieldMask2D{T}(Adapt.adapt(to, f.cc), Adapt.adapt(to, f.vv),
+                   Adapt.adapt(to, f.vc), Adapt.adapt(to, f.cv))
+end
+
+function Adapt.adapt_structure(to, f::FieldMask3D{T}) where {T}
+    FieldMask3D{T}(Adapt.adapt(to, f.ccc),
+                   Adapt.adapt(to, f.vvv),
+                   Adapt.adapt(to, f.vcc),
+                   Adapt.adapt(to, f.cvc),
+                   Adapt.adapt(to, f.ccv),
+                   Adapt.adapt(to, f.vvc),
+                   Adapt.adapt(to, f.vcv),
+                   Adapt.adapt(to, f.cvv))
+end

--- a/src/GridOperators/field_mask.jl
+++ b/src/GridOperators/field_mask.jl
@@ -76,7 +76,7 @@ function FieldMask3D(arch::Architecture, grid::StructuredGrid{3}, type=eltype(gr
     vvc = Field(arch, grid, (Vertex(), Vertex(), Center()), type; kwargs...)
     vcv = Field(arch, grid, (Vertex(), Center(), Vertex()), type; kwargs...)
     cvv = Field(arch, grid, (Center(), Vertex(), Vertex()), type; kwargs...)
-    return FieldMask2D{type}(ccc, vvv, vcc, cvc, ccv, vvc, vcv, cvv)
+    return FieldMask3D{type}(ccc, vvv, vcc, cvc, ccv, vvc, vcv, cvv)
 end
 
 @propagate_inbounds at(ω::FieldMask3D, ::Tuple{Center,Center,Center}, ix, iy, iz) = ω.ccc[ix, iy, iz]

--- a/src/GridOperators/field_mask.jl
+++ b/src/GridOperators/field_mask.jl
@@ -1,0 +1,93 @@
+struct FieldMask1D{T,CF,VF} <: AbstractMask{T,1}
+    c::CF
+    v::VF
+    function FieldMask1D{T}(c::AbstractField{T,1}, v::AbstractField{T,1}) where {T}
+        return new{T,typeof(c),typeof(v)}(c, v)
+    end
+end
+
+function FieldMask1D(arch::Architecture, grid::StructuredGrid{1}, type=eltype(grid); kwargs...)
+    c = Field(arch, grid, Center(), type; kwargs...)
+    v = Field(arch, grid, Vertex(), type; kwargs...)
+    return FieldMask1D{type}(c, v)
+end
+
+@propagate_inbounds at(ω::FieldMask1D, ::Tuple{Center}, ix) = ω.c[ix]
+@propagate_inbounds at(ω::FieldMask1D, ::Tuple{Vertex}, ix) = ω.v[ix]
+
+struct FieldMask2D{T,CCF,VVF,VCF,CVF} <: AbstractMask{T,2}
+    cc::CCF
+    vv::VVF
+    vc::VCF
+    cv::CVF
+    function FieldMask2D{T}(cc::AbstractField{T,2}, vv::AbstractField{T,2}, vc::AbstractField{T,2}, cv::AbstractField{T,2}) where {T}
+        return new{T,typeof(cc),typeof(vv),typeof(vc),typeof(cv)}(cc, vv, vc, cv)
+    end
+end
+
+function FieldMask2D(arch::Architecture, grid::StructuredGrid{2}, type=eltype(grid); kwargs...)
+    cc = Field(arch, grid, Center(), type; kwargs...)
+    vv = Field(arch, grid, Vertex(), type; kwargs...)
+    vc = Field(arch, grid, (Vertex(), Center()), type; kwargs...)
+    cv = Field(arch, grid, (Center(), Vertex()), type; kwargs...)
+    return FieldMask2D{type}(cc, vv, vc, cv)
+end
+
+@propagate_inbounds at(ω::FieldMask2D, ::Tuple{Center,Center}, ix, iy) = ω.cc[ix, iy]
+@propagate_inbounds at(ω::FieldMask2D, ::Tuple{Vertex,Vertex}, ix, iy) = ω.vv[ix, iy]
+@propagate_inbounds at(ω::FieldMask2D, ::Tuple{Vertex,Center}, ix, iy) = ω.vc[ix, iy]
+@propagate_inbounds at(ω::FieldMask2D, ::Tuple{Center,Vertex}, ix, iy) = ω.cv[ix, iy]
+
+struct FieldMask3D{T,CCCF,VVVF,VCCF,CVCF,CCVF,VVCF,VCVF,CVVF} <: AbstractMask{T,3}
+    ccc::CCCF
+    vvv::VVVF
+    vcc::VCCF
+    cvc::CVCF
+    ccv::CCVF
+    vvc::VVCF
+    vcv::VCVF
+    cvv::CVVF
+    function FieldMask3D{T}(ccc::AbstractField{T,3},
+                            vvv::AbstractField{T,3},
+                            vcc::AbstractField{T,3},
+                            cvc::AbstractField{T,3},
+                            ccv::AbstractField{T,3},
+                            vvc::AbstractField{T,3},
+                            vcv::AbstractField{T,3},
+                            cvv::AbstractField{T,3}) where {T}
+        return new{T,
+                   typeof(ccc),
+                   typeof(vvv),
+                   typeof(vcc),
+                   typeof(cvc),
+                   typeof(ccv),
+                   typeof(vvc),
+                   typeof(vcv),
+                   typeof(cvv)}(ccc, vvv, vcc, cvc, ccv, vvc, vcv, cvv)
+    end
+end
+
+function FieldMask3D(arch::Architecture, grid::StructuredGrid{3}, type=eltype(grid); kwargs...)
+    ccc = Field(arch, grid, Center(), type; kwargs...)
+    vvv = Field(arch, grid, Vertex(), type; kwargs...)
+    vcc = Field(arch, grid, (Vertex(), Center(), Center()), type; kwargs...)
+    cvc = Field(arch, grid, (Center(), Vertex(), Center()), type; kwargs...)
+    ccv = Field(arch, grid, (Center(), Center(), Vertex()), type; kwargs...)
+    vvc = Field(arch, grid, (Vertex(), Vertex(), Center()), type; kwargs...)
+    vcv = Field(arch, grid, (Vertex(), Center(), Vertex()), type; kwargs...)
+    cvv = Field(arch, grid, (Center(), Vertex(), Vertex()), type; kwargs...)
+    return FieldMask2D{type}(ccc, vvv, vcc, cvc, ccv, vvc, vcv, cvv)
+end
+
+@propagate_inbounds at(ω::FieldMask3D, ::Tuple{Center,Center,Center}, ix, iy, iz) = ω.ccc[ix, iy, iz]
+@propagate_inbounds at(ω::FieldMask3D, ::Tuple{Vertex,Vertex,Vertex}, ix, iy, iz) = ω.vvv[ix, iy, iz]
+@propagate_inbounds at(ω::FieldMask3D, ::Tuple{Vertex,Center,Center}, ix, iy, iz) = ω.vcc[ix, iy, iz]
+@propagate_inbounds at(ω::FieldMask3D, ::Tuple{Center,Vertex,Center}, ix, iy, iz) = ω.cvc[ix, iy, iz]
+@propagate_inbounds at(ω::FieldMask3D, ::Tuple{Center,Center,Vertex}, ix, iy, iz) = ω.ccv[ix, iy, iz]
+@propagate_inbounds at(ω::FieldMask3D, ::Tuple{Vertex,Vertex,Center}, ix, iy, iz) = ω.vvc[ix, iy, iz]
+@propagate_inbounds at(ω::FieldMask3D, ::Tuple{Vertex,Center,Vertex}, ix, iy, iz) = ω.vcv[ix, iy, iz]
+@propagate_inbounds at(ω::FieldMask3D, ::Tuple{Center,Vertex,Vertex}, ix, iy, iz) = ω.cvv[ix, iy, iz]
+
+FieldMask(arch::Architecture, grid::StructuredGrid{1}, args...; kwargs...) = FieldMask1D(arch, grid, args...; kwargs...)
+FieldMask(arch::Architecture, grid::StructuredGrid{2}, args...; kwargs...) = FieldMask2D(arch, grid, args...; kwargs...)
+FieldMask(arch::Architecture, grid::StructuredGrid{3}, args...; kwargs...) = FieldMask3D(arch, grid, args...; kwargs...)

--- a/src/GridOperators/field_operators.jl
+++ b/src/GridOperators/field_operators.jl
@@ -1,11 +1,27 @@
 # staggered grid operators
-@add_cartesian left(f::AbstractField, dim, I::Vararg{Integer,N}) where {N} = left(f, location(f, dim), flip(location(f, dim)), dim, I...)
+@add_cartesian function left(f::AbstractField, dim, I::Vararg{Integer,N}) where {N}
+    loc  = location(f)
+    from = flipped(loc, dim)
+    left(f, loc, from, dim, I...)
+end
 
-@add_cartesian right(f::AbstractField, dim, I::Vararg{Integer,N}) where {N} = right(f, location(f, dim), flip(location(f, dim)), dim, I...)
+@add_cartesian function right(f::AbstractField, dim, I::Vararg{Integer,N}) where {N}
+    loc  = location(f)
+    from = flipped(loc, dim)
+    right(f, loc, from, dim, I...)
+end
 
-@add_cartesian δ(f::AbstractField, dim, I::Vararg{Integer,N}) where {N} = δ(f, location(f, dim), flip(location(f, dim)), dim, I...)
+@add_cartesian function δ(f::AbstractField, dim, I::Vararg{Integer,N}) where {N}
+    loc  = location(f)
+    from = flipped(loc, dim)
+    return δ(f, loc, from, dim, I...)
+end
 
-@add_cartesian ∂(f::AbstractField, grid, dim, I::Vararg{Integer,N}) where {N} = ∂(f, location(f, dim), flip(location(f, dim)), grid, dim, I...)
+@add_cartesian function ∂(f::AbstractField, grid, dim, I::Vararg{Integer,N}) where {N}
+    loc  = location(f)
+    from = flipped(loc, dim)
+    ∂(f, loc, from, grid, dim, I...)
+end
 
 # covariant derivatives
 @propagate_inbounds @generated function divg(V::NamedTuple{names,<:NTuple{N,AbstractField}}, grid::StructuredGrid{N}, I::Vararg{Integer,N}) where {names,N}

--- a/src/GridOperators/field_operators.jl
+++ b/src/GridOperators/field_operators.jl
@@ -7,54 +7,6 @@
 
 @add_cartesian ∂(f::AbstractField, grid, dim, I::Vararg{Integer,N}) where {N} = ∂(f, location(f, dim), flip(location(f, dim)), grid, dim, I...)
 
-# staggered operators on Cartesian grids
-for (dim, coord) in enumerate((:x, :y, :z))
-    _l = Symbol(:left, coord)
-    _r = Symbol(:right, coord)
-    _δ = Symbol(:δ, coord)
-    _∂ = Symbol(:∂, coord)
-
-    @eval begin
-        export $_δ, $_∂, $_l, $_r
-
-        """
-            $($_l)(f, I)
-
-        "left side" of a field (`[1:end-1]`) in $($(string(coord))) direction.
-        """
-        @add_cartesian function $_l(f::AbstractField, I::Vararg{Integer,N}) where {N}
-            left(f, Dim($dim), I...)
-        end
-
-        """
-            $($_r)(f, I)
-
-        "right side" of a field (`[2:end]`) in $($(string(coord))) direction.
-        """
-        @add_cartesian function $_r(f::AbstractField, I::Vararg{Integer,N}) where {N}
-            right(f, Dim($dim), I...)
-        end
-
-        """
-            $($_δ)(f, I)
-
-        Finite difference in $($(string(coord))) direction.
-        """
-        @add_cartesian function $_δ(f::AbstractField, I::Vararg{Integer,N}) where {N}
-            δ(f, Dim($dim), I...)
-        end
-
-        """
-            $($_∂)(f, grid, I)
-
-        Directional partial derivative in $($(string(coord))) direction.
-        """
-        @add_cartesian function $_∂(f::AbstractField, grid, I::Vararg{Integer,N}) where {N}
-            ∂(f, grid, Dim($dim), I...)
-        end
-    end
-end
-
 # covariant derivatives
 @propagate_inbounds @generated function divg(V::NamedTuple{names,<:NTuple{N,AbstractField}}, grid::StructuredGrid{N}, I::Vararg{Integer,N}) where {names,N}
     quote

--- a/src/GridOperators/masked_cartesian_field_operators.jl
+++ b/src/GridOperators/masked_cartesian_field_operators.jl
@@ -1,0 +1,46 @@
+for (dim, coord) in enumerate((:x, :y, :z))
+    _l = Symbol(:left, coord)
+    _r = Symbol(:right, coord)
+    _δ = Symbol(:δ, coord)
+    _∂ = Symbol(:∂, coord)
+
+    @eval begin
+        export $_δ, $_∂, $_l, $_r
+
+        """
+            $($_l)(f, ω, I)
+
+        "left side" of a field (`[1:end-1]`) in $($(string(coord))) direction, masked with `ω`.
+        """
+        @add_cartesian function $_l(f::AbstractField, ω::AbstractMask, I::Vararg{Integer,N}) where {N}
+            left(f, ω, Dim($dim), I...)
+        end
+
+        """
+            $($_r)(f, ω, I)
+
+        "right side" of a field (`[2:end]`) in $($(string(coord))) direction, masked with `ω`.
+        """
+        @add_cartesian function $_r(f::AbstractField, ω::AbstractMask, I::Vararg{Integer,N}) where {N}
+            right(f, ω, Dim($dim), I...)
+        end
+
+        """
+            $($_δ)(f, ω, I)
+
+        Finite difference in $($(string(coord))) direction, masked with `ω`.
+        """
+        @add_cartesian function $_δ(f::AbstractField, ω::AbstractMask, I::Vararg{Integer,N}) where {N}
+            δ(f, ω, Dim($dim), I...)
+        end
+
+        """
+            $($_∂)(f, ω, grid, I)
+
+        Directional partial derivative in $($(string(coord))) direction, masked with `ω`.
+        """
+        @add_cartesian function $_∂(f::AbstractField, ω::AbstractMask, grid, I::Vararg{Integer,N}) where {N}
+            ∂(f, ω, grid, Dim($dim), I...)
+        end
+    end
+end

--- a/src/GridOperators/masked_field_operators.jl
+++ b/src/GridOperators/masked_field_operators.jl
@@ -1,0 +1,28 @@
+# staggered grid operators
+@add_cartesian left(f::AbstractField, ω::AbstractMask, dim, I::Vararg{Integer,N}) where {N} = left(f, location(f, dim), flip(location(f, dim)), ω, dim, I...)
+
+@add_cartesian right(f::AbstractField, ω::AbstractMask, dim, I::Vararg{Integer,N}) where {N} = right(f, location(f, dim), flip(location(f, dim)), ω, dim, I...)
+
+@add_cartesian δ(f::AbstractField, ω::AbstractMask, dim, I::Vararg{Integer,N}) where {N} = δ(f, location(f, dim), flip(location(f, dim)), ω, dim, I...)
+
+@add_cartesian function ∂(f::AbstractField, ω::AbstractMask, grid, dim, I::Vararg{Integer,N}) where {N}
+    return ∂(f, location(f, dim), flip(location(f, dim)), ω, grid, dim, I...)
+end
+
+# covariant derivatives
+@propagate_inbounds @generated function divg(V::NamedTuple{names,<:NTuple{N,AbstractField}},
+                                             ω::AbstractMask{T,N},
+                                             grid::StructuredGrid{N},
+                                             I::Vararg{Integer,N}) where {names,T,N}
+    quote
+        @inline
+        Base.Cartesian.@ncall $N (+) D -> ∂(V[D], ω, grid, Dim(D), I...)
+    end
+end
+
+@propagate_inbounds function divg(V::NamedTuple{names,<:NTuple{N,AbstractField}},
+                                  ω::AbstractMask{T,N},
+                                  grid::StructuredGrid{N},
+                                  I::CartesianIndex{N}) where {names,T,N}
+    return divg(V, ω, grid, Tuple(I)...)
+end

--- a/src/GridOperators/masked_field_operators.jl
+++ b/src/GridOperators/masked_field_operators.jl
@@ -1,12 +1,26 @@
 # staggered grid operators
-@add_cartesian left(f::AbstractField, ω::AbstractMask, dim, I::Vararg{Integer,N}) where {N} = left(f, location(f, dim), flip(location(f, dim)), ω, dim, I...)
+@add_cartesian function left(f::AbstractField, ω::AbstractMask, dim, I::Vararg{Integer,N}) where {N}
+    loc  = location(f)
+    from = flipped(loc, dim)
+    return left(f, loc, from, ω, dim, I...)
+end
 
-@add_cartesian right(f::AbstractField, ω::AbstractMask, dim, I::Vararg{Integer,N}) where {N} = right(f, location(f, dim), flip(location(f, dim)), ω, dim, I...)
+@add_cartesian function right(f::AbstractField, ω::AbstractMask, dim, I::Vararg{Integer,N}) where {N}
+    loc  = location(f)
+    from = flipped(loc, dim)
+    return right(f, loc, from, ω, dim, I...)
+end
 
-@add_cartesian δ(f::AbstractField, ω::AbstractMask, dim, I::Vararg{Integer,N}) where {N} = δ(f, location(f, dim), flip(location(f, dim)), ω, dim, I...)
+@add_cartesian function δ(f::AbstractField, ω::AbstractMask, dim, I::Vararg{Integer,N}) where {N}
+    loc  = location(f)
+    from = flipped(loc, dim)
+    δ(f, loc, from, ω, dim, I...)
+end
 
 @add_cartesian function ∂(f::AbstractField, ω::AbstractMask, grid, dim, I::Vararg{Integer,N}) where {N}
-    return ∂(f, location(f, dim), flip(location(f, dim)), ω, grid, dim, I...)
+    loc  = location(f)
+    from = flipped(loc, dim)
+    return ∂(f, loc, from, ω, grid, dim, I...)
 end
 
 # covariant derivatives

--- a/src/GridOperators/masked_operators.jl
+++ b/src/GridOperators/masked_operators.jl
@@ -1,14 +1,14 @@
 abstract type AbstractMask{T,N} end
 
-@add_cartesian at(ω::AbstractMask{T,N}, loc::Location, I::Vararg{Integer,N}) where {T,N} = at(ω, expand_loc(Val(N), loc), I...)
+@propagate_inbounds at(ω::AbstractMask{T,N}, loc::NTuple{N,Location}, I::CartesianIndex{N}) where {T,N} = at(ω, loc, Tuple(I)...)
 
-@add_cartesian function left(f, loc, from, ω::AbstractMask, dim, I::Vararg{Integer,N}) where {N}
-    Il = il(loc, from, dim, I...)
+@add_cartesian function left(f, loc::NTuple{N,Location}, from::NTuple{N,Location}, ω::AbstractMask, dim::Dim{D}, I::Vararg{Integer,N}) where {N,D}
+    Il = il(loc[D], from[D], dim, I...)
     return f[Il...] * at(ω, loc, Il...)
 end
 
-@add_cartesian function right(f, loc, from, ω::AbstractMask, dim, I::Vararg{Integer,N}) where {N}
-    Ir = ir(loc, from, dim, I...)
+@add_cartesian function right(f, loc::NTuple{N,Location}, from::NTuple{N,Location}, ω::AbstractMask, dim::Dim{D}, I::Vararg{Integer,N}) where {N,D}
+    Ir = ir(loc[D], from[D], dim, I...)
     return f[Ir...] * at(ω, loc, Ir...)
 end
 

--- a/src/GridOperators/masked_operators.jl
+++ b/src/GridOperators/masked_operators.jl
@@ -1,0 +1,17 @@
+abstract type AbstractMask{T,N} end
+
+@add_cartesian at(ω::AbstractMask{T,N}, loc::Location, I::Vararg{Integer,N}) where {T,N} = at(ω, expand_loc(Val(N), loc), I...)
+
+@add_cartesian function left(f, loc, from, ω::AbstractMask, dim, I::Vararg{Integer,N}) where {N}
+    Il = il(loc, from, dim, I...)
+    return f[Il...] * at(ω, loc, Il...)
+end
+
+@add_cartesian function right(f, loc, from, ω::AbstractMask, dim, I::Vararg{Integer,N}) where {N}
+    Ir = ir(loc, from, dim, I...)
+    return f[Ir...] * at(ω, loc, Ir...)
+end
+
+@add_cartesian δ(f, loc, from, ω::AbstractMask, dim, I::Vararg{Integer,N}) where {N} = right(f, loc, from, ω, dim, I...) - left(f, loc, from, ω, dim, I...)
+
+@add_cartesian ∂(f, loc, from, ω::AbstractMask, grid, dim, I::Vararg{Integer,N}) where {N} = δ(f, loc, from, ω, dim, I...) * iΔ(grid, loc, dim, I...)

--- a/src/Grids/Grids.jl
+++ b/src/Grids/Grids.jl
@@ -5,7 +5,7 @@ export Connectivity, Bounded, Connected, Periodic, Flat
 export AbstractAxis, UniformAxis, FunctionAxis
 export StructuredGrid, UniformGrid
 
-export nvertices, ncenters, spacing, inv_spacing, Δ, iΔ, coord, coords, center, vertex, centers, vertices
+export nvertices, ncenters, spacing, inv_spacing, Δ, iΔ, volume, inv_volume, coord, coords, center, vertex, centers, vertices
 export origin, extent, bounds, axis
 export direction, axes_names
 export expand_loc

--- a/src/Grids/structured_grid.jl
+++ b/src/Grids/structured_grid.jl
@@ -226,3 +226,27 @@ direction(::SG, ::Val{:z}) = Dim(3)
 axes_names(::SG{1}) = (:x,)
 axes_names(::SG{2}) = (:x, :y)
 axes_names(::SG{3}) = (:x, :y, :z)
+
+# cell volumes
+for (vol, sp, desc) in ((:volume, :spacing, "control volume"), (:inv_volume, :inv_spacing, "inverse of control volume"))
+    @eval begin
+        """
+            $($vol)(grid, loc, I...)
+
+        Return the $($desc) at location `loc` and indices `I`.
+        """
+        @add_cartesian function $vol(grid::StructuredGrid{N}, locs::NTuple{N,Location}, I::Vararg{Integer,N}) where {N}
+            return ntuple(Val(N)) do D
+                Base.@_inline_meta
+                $sp(grid.axes[D], locs[D], I[D])
+            end |> prod
+        end
+
+        @add_cartesian function $vol(grid::StructuredGrid{N}, loc::Location, I::Vararg{Integer,N}) where {N}
+            return ntuple(Val(N)) do D
+                Base.@_inline_meta
+                $sp(grid.axes[D], loc, I[D])
+            end |> prod
+        end
+    end
+end

--- a/src/KernelLaunch.jl
+++ b/src/KernelLaunch.jl
@@ -1,6 +1,6 @@
 module KernelLaunch
 
-export Launcher, Offset
+export Launcher
 export worksize, outer_width, inner_worksize, inner_offset, outer_worksize, outer_offset
 
 using Chmy
@@ -10,17 +10,6 @@ using Chmy.BoundaryConditions
 using Chmy.Workers
 
 using KernelAbstractions
-
-struct Offset{O} end
-
-Offset(o::Vararg{Integer}) = Offset{o}()
-Offset() = Offset{0}()
-
-Base.:+(::Offset{O1}, ::Offset{O2}) where {O1,O2} = Offset((O1 .+ O2)...)
-Base.:+(::Offset{O}, tp::Tuple{Vararg{Integer}}) where {O} = O .+ tp
-Base.:+(::Offset{O}, tp::CartesianIndex) where {O} = CartesianIndex(O .+ Tuple(tp))
-
-Base.:+(tp, off::Offset) = off + tp
 
 struct Launcher{Worksize,OuterWidth,Workers}
     workers::Workers

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -57,3 +57,16 @@ Takes a tuple `A` and inserts a new element `i` at position specified by `dim`.
 Takes a CartesianIndex `I` and inserts a new element `i` at position specified by `dim`.
 """
 @inline insert_dim(dim, I::CartesianIndex, i) = insert_dim(dim, Tuple(I), i) |> CartesianIndex
+
+struct Offset{O} end
+
+Offset(o::Vararg{Integer}) = Offset{o}()
+Offset(o::Tuple{Vararg{Integer}}) = Offset{o}()
+Offset(o::CartesianIndex) = Offset{o.I}()
+Offset() = Offset{0}()
+
+Base.:+(::Offset{O1}, ::Offset{O2}) where {O1,O2} = Offset((O1 .+ O2)...)
+Base.:+(::Offset{O}, tp::Tuple{Vararg{Integer}}) where {O} = O .+ tp
+Base.:+(::Offset{O}, tp::CartesianIndex) where {O} = CartesianIndex(O .+ Tuple(tp))
+
+Base.:+(tp, off::Offset) = off + tp


### PR DESCRIPTION
This PR extends the existing GridOperators API with new functions to compute masked derivatives, where each operand is premultiplied with a mask at corresponding grid location.