### PR TITLE
Improve perf of `_set_continuous!` & `_set_discrete!`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Chmy"
 uuid = "33a72cf0-4690-46d7-b987-06506c2248b9"
 authors = ["Ivan Utkin <iutkin@ethz.ch>, Ludovic Raess <ludovic.rass@gmail.com>, and contributors"]
-version = "0.1.15"
+version = "0.1.16"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"

--- a/src/Fields/field.jl
+++ b/src/Fields/field.jl
@@ -73,12 +73,12 @@ end
     dst[I...] = src[I...]
 end
 
-@kernel inbounds = true function _set_continuous!(dst, grid, loc, fun::F, args...) where {F}
+@kernel inbounds = true function _set_continuous!(dst, grid, loc, fun::F, args::Vararg{Any, N}) where {F, N}
     I = @index(Global, NTuple)
     dst[I...] = fun(coord(grid, loc, I...)..., args...)
 end
 
-@kernel inbounds = true function _set_discrete!(dst, grid, loc, fun::F, args...) where {F}
+@kernel inbounds = true function _set_discrete!(dst, grid, loc, fun::F, args::Vararg{Any, N}) where {F, N}
     I = @index(Global, NTuple)
     dst[I...] = fun(grid, loc, I..., args...)
 end


### PR DESCRIPTION
Adds a `Vararg` signature at the end of `_set_continuous!` and `_set_discrete!` so that the compiler can specialize.

```julia
@kernel inbounds = true function _set_continuous!(dst, grid, loc, fun::F, args::Vararg{Any, N}) where {F, N}
    I = @index(Global, NTuple)
    dst[I...] = fun(coord(grid, loc, I...)..., args...)
end

@kernel inbounds = true function _set_discrete!(dst, grid, loc, fun::F, args::Vararg{Any, N}) where {F, N}
    I = @index(Global, NTuple)
    dst[I...] = fun(grid, loc, I..., args...)
end
```

Example:
```julia
using Chmy, Chmy.Architectures, Chmy.Grids, Chmy.Fields, Chmy.BoundaryConditions, Chmy.GridOperators, Chmy.KernelLaunch

backend=CPU(); nxy=(126, 126)
arch = Arch(backend)
# geometry
grid   = UniformGrid(arch; origin=(-1, -1), extent=(2, 2), dims=nxy)
launch = Launcher(arch, grid; outer_width=(16, 8))
allocate fields
C = Field(backend, grid, Center())
init_incl(x, y, x0, y0, r, in, out) = ifelse((x - x0)^2 + (y - y0)^2 < r^2, in, out)
```

`#main`:
```julia
using Chairmarks
julia> @b set!($(C, grid, init_incl)...; parameters=(x0=0.0, y0=0.0, r=0.1, in=1, out=0))
705.100 μs (112084 allocs: 1.980 MiB)
```

This PR
```julia
julia> @b set!($(C, grid, init_incl)...; parameters=(x0=0.0, y0=0.0, r=0.1, in=1, out=0))
8.650 μs (70 allocs: 7.266 KiB)
```