### PR TITLE
Fixed raw image url for documentation

### DIFF
--- a/docs/src/concepts/distributed.md
+++ b/docs/src/concepts/distributed.md
@@ -11,7 +11,7 @@ Each node manages its own private memory. Such system with interconnected nodes,
 
 ```@raw html
 <center>
-    <img src="../assets/compute_cluster.jpg" width="35%"/>
+    <img src="https://raw.githubusercontent.com/PTsolvers/Chmy.jl/main/docs/src/assets/compute_cluster.jpg" width="35%"/>
 </center>
 ```
 


### PR DESCRIPTION
Using the relative path for images results in the image not found on the documentation website, this PR fixed the newly added image for the doc.