### PR TITLE
Fix Metal CI

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Chmy"
 uuid = "33a72cf0-4690-46d7-b987-06506c2248b9"
 authors = ["Ivan Utkin <iutkin@ethz.ch>, Ludovic Raess <ludovic.rass@gmail.com>, and contributors"]
-version = "0.1.21"
+version = "0.1.22"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"

--- a/test/test_fields.jl
+++ b/test/test_fields.jl
@@ -20,34 +20,34 @@ for backend in TEST_BACKENDS, T in TEST_TYPES
             f = Field(backend, grid, (Center(), Vertex(), Center()); halo=(1, 0, 1))
             @testset "discrete" begin
                 # no parameters vertex
-                fill!(parent(f), NaN)
+                fill!(parent(f), T(NaN))
                 set!(f, grid, (grid, loc, ix, iy, iz) -> ycoord(grid, loc, iy); discrete=true)
                 @test Array(interior(f)) == [0.0; 0.0;; 0.5; 0.5;; 1.0; 1.0;;;
                                                 0.0; 0.0;; 0.5; 0.5;; 1.0; 1.0]
                 # no parameters center
-                fill!(parent(f), NaN)
+                fill!(parent(f), T(NaN))
                 set!(f, grid, (grid, loc, ix, iy, iz) -> xcoord(grid, loc, ix); discrete=true)
                 @test Array(interior(f)) == [0.25; 0.75;; 0.25; 0.75;; 0.25; 0.75;;;
                                                 0.25; 0.75;; 0.25; 0.75;; 0.25; 0.75]
                 # with parameters
-                fill!(parent(f), NaN)
+                fill!(parent(f), T(NaN))
                 set!(f, grid, (grid, loc, ix, iy, iz, sc) -> ycoord(grid, loc, iy) * sc; discrete=true, parameters=(T(2.0),))
                 @test Array(interior(f)) == [0.0; 0.0;; 1.0; 1.0;; 2.0; 2.0;;;
                                                 0.0; 0.0;; 1.0; 1.0;; 2.0; 2.0]
             end
             @testset "continuous" begin
                 # no parameters vertex
-                fill!(parent(f), NaN)
+                fill!(parent(f), T(NaN))
                 set!(f, grid, (x, y, z) -> y)
                 @test Array(interior(f)) == [0.0; 0.0;; 0.5; 0.5;; 1.0; 1.0;;;
                                                 0.0; 0.0;; 0.5; 0.5;; 1.0; 1.0]
                 # no parameters center
-                fill!(parent(f), NaN)
+                fill!(parent(f), T(NaN))
                 set!(f, grid, (x, y, z) -> x)
                 @test Array(interior(f)) == [0.25; 0.75;; 0.25; 0.75;; 0.25; 0.75;;;
                                                 0.25; 0.75;; 0.25; 0.75;; 0.25; 0.75]
                 # with parameters
-                fill!(parent(f), NaN)
+                fill!(parent(f), T(NaN))
                 set!(f, grid, (x, y, z, sc) -> y * sc; parameters=(T(2.0),))
                 @test Array(interior(f)) == [0.0; 0.0;; 1.0; 1.0;; 2.0; 2.0;;;
                                                 0.0; 0.0;; 1.0; 1.0;; 2.0; 2.0]


### PR DESCRIPTION
This PR fixes the fact that using `NaN` with Metal kernels requires `NaN32` or here, for testing purposes, casting into `Float32(NaN)`.

Closes #67.