### PR TITLE
Adding number tensor notation

### DIFF
--- a/src/BoundaryConditions/batch.jl
+++ b/src/BoundaryConditions/batch.jl
@@ -140,6 +140,12 @@ function regularise_exchange(grid, fields::NamedTuple{named_dims,<:Tuple{Vararg{
     return merge(default_exchange(grid), fields) |> Tuple
 end
 
+function regularise_exchange(grid, v::VectorField{N}) where {N}
+    names = axes_names(grid)
+    nt = NamedTuple{names}(getfield(v, :components))
+    return merge(default_exchange(grid), nt) |> Tuple
+end
+
 @inline function reorder(conditions::NTuple{K,NTuple{N,SidesBCs}}) where {K,N}
     ntuple(Val(N)) do D
         Base.@_inline_meta

--- a/src/Chmy.jl
+++ b/src/Chmy.jl
@@ -4,81 +4,71 @@ using MacroTools
 using KernelAbstractions
 
 export
-    # utils
-    Dim, Side, Left, Right, remove_dim, insert_dim, Offset,
+# utils
+      Dim, Side, Left, Right, remove_dim, insert_dim, Offset,
 
-    # Architectures
-    Architecture, SingleDeviceArchitecture, Arch, get_backend, get_device, activate!, set_device!,
-    heuristic_groupsize, pointertype,
+# Architectures
+      Architecture, SingleDeviceArchitecture, Arch, get_backend, get_device, activate!, set_device!,
+      heuristic_groupsize, pointertype,
 
-    # BoundaryConditions
-    FieldBoundaryCondition, FirstOrderBC, Dirichlet, Neumann, bc!,
-    BoundaryFunction,
-    DimSide,
-    AbstractBatch, FieldBatch, ExchangeBatch, EmptyBatch, BatchSet, batch,
+# BoundaryConditions
+      FieldBoundaryCondition, FirstOrderBC, Dirichlet, Neumann, bc!,
+      BoundaryFunction,
+      DimSide,
+      AbstractBatch, FieldBatch, ExchangeBatch, EmptyBatch, BatchSet, batch,
 
-    # Distributed
-    CartesianTopology, global_rank, shared_rank, node_name, cart_comm, shared_comm,
-    dims, cart_coords, neighbors, neighbor, has_neighbor, global_size, node_size,
-    DistributedArchitecture, topology, is_gpu_aware,
-    exchange_halo!, gather!,
+# Distributed
+      CartesianTopology, global_rank, shared_rank, node_name, cart_comm, shared_comm,
+      dims, cart_coords, neighbors, neighbor, has_neighbor, global_size, node_size,
+      DistributedArchitecture, topology, is_gpu_aware,
+      exchange_halo!, gather!,
 
-    # DoubleBuffer
-    DoubleBuffer, swap!, front, back,
+# DoubleBuffer
+      DoubleBuffer, swap!, front, back,
 
-    # Fields
-    AbstractField, Field, VectorField, TensorField, ConstantField, ZeroField, OneField, ValueField, FunctionField,
-    location, halo, interior, set!,
-    divg,
+# Fields
+      AbstractField, Field, VectorField, TensorField, ConstantField, ZeroField, OneField, ValueField, FunctionField,
+      location, halo, interior, set!,
+      divg,
 
-    # Grids
-    Location, Center, Vertex, flip,
-    Connectivity, Bounded, Connected, Periodic, Flat,
-    AbstractAxis, UniformAxis, FunctionAxis,
-    StructuredGrid, UniformGrid,
-    nvertices, ncenters, spacing, inv_spacing, Δ, iΔ, volume, inv_volume,
-    coord, coords, center, vertex, centers, vertices,
-    origin, extent, bounds, axis,
-    direction, axes_names, expand_loc,
-    connectivity,
+# Grids
+      Location, Center, Vertex, flip,
+      Connectivity, Bounded, Connected, Periodic, Flat,
+      AbstractAxis, UniformAxis, FunctionAxis,
+      StructuredGrid, UniformGrid,
+      nvertices, ncenters, spacing, inv_spacing, Δ, iΔ, volume, inv_volume,
+      coord, coords, center, vertex, centers, vertices,
+      origin, extent, bounds, axis,
+      direction, axes_names, expand_loc,
+      connectivity, Δx, Δy, Δz,
+      xcoord, ycoord, zcoord,
+      xcoords, ycoords, zcoords,
+      xvertex, yvertex, zvertex,
+      xcenter, ycenter, zcenter,
+      xvertices, yvertices, zvertices,
+      xcenters, ycenters, zcenters,
 
-    Δx, Δy, Δz,
-    xcoord, ycoord, zcoord,
-    xcoords, ycoords, zcoords,
-    xvertex, yvertex, zvertex,
-    xcenter, ycenter, zcenter,
-    xvertices, yvertices, zvertices,
-    xcenters, ycenters, zcenters,
+# GridOperators
+      left, right, δ, ∂, ∂², ∂k∂,
+      InterpolationRule, Linear, HarmonicLinear,
+      itp, lerp, hlerp,
+      divg, divg_grad, lapl, vmag,
+      AbstractMask, FieldMask, FieldMask1D, FieldMask2D, FieldMask3D, at, leftx, rightx, δx, ∂x, ∂²x, ∂k∂x,
+      lefty, righty, δy, ∂y, ∂²y, ∂k∂y,
+      leftz, rightz, δz, ∂z, ∂²z, ∂k∂z, left1, right1, δ1, ∂1, ∂²1, ∂k∂1,
+      left2, right2, δ2, ∂2, ∂²2, ∂k∂2,
+      left3, right3, δ3, ∂3, ∂²3, ∂k∂3, leftx_masked, rightx_masked, δx_masked, ∂x_masked, ∂²x_masked, ∂k∂x_masked,
+      lefty_masked, righty_masked, δy_masked, ∂y_masked, ∂²y_masked, ∂k∂y_masked,
+      leftz_masked, rightz_masked, δz_masked, ∂z_masked, ∂²z_masked, ∂k∂z_masked, left1_masked, right1_masked, δ1_masked, ∂1_masked, ∂²1_masked, ∂k∂1_masked,
+      left2_masked, right2_masked, δ2_masked, ∂2_masked, ∂²2_masked, ∂k∂2_masked,
+      left3_masked, right3_masked, δ3_masked, ∂3_masked, ∂²3_masked, ∂k∂3_masked,
 
-    # GridOperators
-    left, right, δ, ∂, ∂², ∂k∂,
-    InterpolationRule, Linear, HarmonicLinear,
-    itp, lerp, hlerp,
-    divg, divg_grad, lapl, vmag,
-    AbstractMask, FieldMask, FieldMask1D, FieldMask2D, FieldMask3D, at,
+# KernelLaunch
+      Launcher,
+      worksize, outer_width, inner_worksize, inner_offset, outer_worksize, outer_offset,
 
-    leftx, rightx, δx, ∂x, ∂²x, ∂k∂x,
-    lefty, righty, δy, ∂y, ∂²y, ∂k∂y,
-    leftz, rightz, δz, ∂z, ∂²z, ∂k∂z,
-
-    left1, right1, δ1, ∂1, ∂²1, ∂k∂1,
-    left2, right2, δ2, ∂2, ∂²2, ∂k∂2,
-    left3, right3, δ3, ∂3, ∂²3, ∂k∂3,
-
-    leftx_masked, rightx_masked, δx_masked, ∂x_masked, ∂²x_masked, ∂k∂x_masked,
-    lefty_masked, righty_masked, δy_masked, ∂y_masked, ∂²y_masked, ∂k∂y_masked,
-    leftz_masked, rightz_masked, δz_masked, ∂z_masked, ∂²z_masked, ∂k∂z_masked,
-
-    left1_masked, right1_masked, δ1_masked, ∂1_masked, ∂²1_masked, ∂k∂1_masked,
-    left2_masked, right2_masked, δ2_masked, ∂2_masked, ∂²2_masked, ∂k∂2_masked,
-    left3_masked, right3_masked, δ3_masked, ∂3_masked, ∂²3_masked, ∂k∂3_masked,
-
-    # KernelLaunch
-    Launcher,
-    worksize, outer_width, inner_worksize, inner_offset, outer_worksize, outer_offset,
-
-    # Workers
-    Worker
+# Workers
+      Worker
 
 include("macros.jl")
 include("utils.jl")

--- a/src/Chmy.jl
+++ b/src/Chmy.jl
@@ -61,9 +61,17 @@ export
     lefty, righty, δy, ∂y, ∂²y, ∂k∂y,
     leftz, rightz, δz, ∂z, ∂²z, ∂k∂z,
 
+    left1, right1, δ1, ∂1, ∂²1, ∂k∂1,
+    left2, right2, δ2, ∂2, ∂²2, ∂k∂2,
+    left3, right3, δ3, ∂3, ∂²3, ∂k∂3,
+
     leftx_masked, rightx_masked, δx_masked, ∂x_masked, ∂²x_masked, ∂k∂x_masked,
     lefty_masked, righty_masked, δy_masked, ∂y_masked, ∂²y_masked, ∂k∂y_masked,
     leftz_masked, rightz_masked, δz_masked, ∂z_masked, ∂²z_masked, ∂k∂z_masked,
+
+    left1_masked, right1_masked, δ1_masked, ∂1_masked, ∂²1_masked, ∂k∂1_masked,
+    left2_masked, right2_masked, δ2_masked, ∂2_masked, ∂²2_masked, ∂k∂2_masked,
+    left3_masked, right3_masked, δ3_masked, ∂3_masked, ∂²3_masked, ∂k∂3_masked,
 
     # KernelLaunch
     Launcher,

--- a/src/Fields/field.jl
+++ b/src/Fields/field.jl
@@ -118,12 +118,12 @@ end
     dst[I...] = src[I...]
 end
 
-@kernel inbounds = true function _set_continuous!(dst, grid, loc, fun::F, args::Vararg{Any, N}) where {F, N}
+@kernel inbounds = true function _set_continuous!(dst, grid, loc, fun::F, args::Vararg{Any,N}) where {F,N}
     I = @index(Global, NTuple)
     dst[I...] = fun(coord(grid, loc, I...)..., args...)
 end
 
-@kernel inbounds = true function _set_discrete!(dst, grid, loc, fun::F, args::Vararg{Any, N}) where {F, N}
+@kernel inbounds = true function _set_discrete!(dst, grid, loc, fun::F, args::Vararg{Any,N}) where {F,N}
     I = @index(Global, NTuple)
     dst[I...] = fun(grid, loc, I..., args...)
 end
@@ -153,9 +153,9 @@ vector_location(::Val{dim}, ::Val{N}) where {dim,N} = ntuple(i -> i == dim ? Ver
 A vector field of N components, each a `Field` at its staggered location.
 Components are accessible via dot notation (`v.x`, `v.y`, `v.z`) or integer indexing (`v[1]`, `v[2]`, `v[3]`).
 """
-struct VectorField{N, C <: Tuple}
+struct VectorField{N,C<:Tuple}
     components::C
-    VectorField{N}(components::C) where {N, C <: Tuple} = new{N, C}(components)
+    VectorField{N}(components::C) where {N,C<:Tuple} = new{N,C}(components)
 end
 
 """
@@ -168,18 +168,18 @@ two-index notation (`t[1,1]`, `t[1,2]`, etc., with symmetry: `t[i,j] == t[j,i]`)
 2D components (in order): `xx, yy, xy`
 3D components (in order): `xx, yy, zz, xy, xz, yz`
 """
-struct TensorField{N, C <: Tuple}
+struct TensorField{N,C<:Tuple}
     components::C
-    TensorField{N}(components::C) where {N, C <: Tuple} = new{N, C}(components)
+    TensorField{N}(components::C) where {N,C<:Tuple} = new{N,C}(components)
 end
 
 # --- VectorField accessors ---
 
 function Base.getproperty(v::VectorField, s::Symbol)
     s === :components && return getfield(v, :components)
-    s === :x          && return getfield(v, :components)[1]
-    s === :y          && return getfield(v, :components)[2]
-    s === :z          && return getfield(v, :components)[3]
+    s === :x && return getfield(v, :components)[1]
+    s === :y && return getfield(v, :components)[2]
+    s === :z && return getfield(v, :components)[3]
     error("VectorField has no property $s")
 end
 
@@ -196,8 +196,8 @@ Base.length(::VectorField{N}) where {N} = N
 
 function Base.getproperty(t::TensorField{N}, s::Symbol) where {N}
     s === :components && return getfield(t, :components)
-    s === :xx         && return getfield(t, :components)[1]
-    s === :yy         && return getfield(t, :components)[2]
+    s === :xx && return getfield(t, :components)[1]
+    s === :yy && return getfield(t, :components)[2]
     if N == 3
         s === :zz && return getfield(t, :components)[3]
         s === :xy && return getfield(t, :components)[4]
@@ -239,11 +239,9 @@ set!(t::TensorField, args...) = foreach(f -> set!(f, args...), getfield(t, :comp
 
 # --- GPU adaptation ---
 
-Adapt.adapt_structure(to, v::VectorField{N}) where {N} =
-    VectorField{N}(map(f -> Adapt.adapt(to, f), getfield(v, :components)))
+Adapt.adapt_structure(to, v::VectorField{N}) where {N} = VectorField{N}(map(f -> Adapt.adapt(to, f), getfield(v, :components)))
 
-Adapt.adapt_structure(to, t::TensorField{N}) where {N} =
-    TensorField{N}(map(f -> Adapt.adapt(to, f), getfield(t, :components)))
+Adapt.adapt_structure(to, t::TensorField{N}) where {N} = TensorField{N}(map(f -> Adapt.adapt(to, f), getfield(t, :components)))
 
 # --- factory functions ---
 
@@ -269,11 +267,9 @@ Create a 2D symmetric `TensorField`. Components `(xx, yy, xy)` are stored in ord
 Access via `t.xx`/`t.yy`/`t.xy` or `t[1,1]`/`t[2,2]`/`t[1,2]` (symmetric: `t[i,j] == t[j,i]`).
 """
 function TensorField(backend::Backend, grid::StructuredGrid{2}, args...; kwargs...)
-    components = (
-        Field(backend, grid, Center(), args...; kwargs...),
-        Field(backend, grid, Center(), args...; kwargs...),
-        Field(backend, grid, Vertex(), args...; kwargs...),
-    )
+    components = (Field(backend, grid, Center(), args...; kwargs...),
+                  Field(backend, grid, Center(), args...; kwargs...),
+                  Field(backend, grid, Vertex(), args...; kwargs...))
     return TensorField{2}(components)
 end
 
@@ -284,14 +280,12 @@ Create a 3D symmetric `TensorField`. Components `(xx, yy, zz, xy, xz, yz)` are s
 Access via `t.xx` etc. or `t[1,1]`/`t[1,2]` etc. (symmetric: `t[i,j] == t[j,i]`).
 """
 function TensorField(backend::Backend, grid::StructuredGrid{3}, args...; kwargs...)
-    components = (
-        Field(backend, grid, Center(), args...; kwargs...),
-        Field(backend, grid, Center(), args...; kwargs...),
-        Field(backend, grid, Center(), args...; kwargs...),
-        Field(backend, grid, (Vertex(), Vertex(), Center()), args...; kwargs...),
-        Field(backend, grid, (Vertex(), Center(), Vertex()), args...; kwargs...),
-        Field(backend, grid, (Center(), Vertex(), Vertex()), args...; kwargs...),
-    )
+    components = (Field(backend, grid, Center(), args...; kwargs...),
+                  Field(backend, grid, Center(), args...; kwargs...),
+                  Field(backend, grid, Center(), args...; kwargs...),
+                  Field(backend, grid, (Vertex(), Vertex(), Center()), args...; kwargs...),
+                  Field(backend, grid, (Vertex(), Center(), Vertex()), args...; kwargs...),
+                  Field(backend, grid, (Center(), Vertex(), Vertex()), args...; kwargs...))
     return TensorField{3}(components)
 end
 

--- a/src/Fields/field.jl
+++ b/src/Fields/field.jl
@@ -148,61 +148,151 @@ set!(fs::NamedTuple{names,<:NTuple{N,Field}}, args...) where {names,N} = foreach
 vector_location(::Val{dim}, ::Val{N}) where {dim,N} = ntuple(i -> i == dim ? Vertex() : Center(), Val(N))
 
 """
+    struct VectorField{N, C <: Tuple}
+
+A vector field of N components, each a `Field` at its staggered location.
+Components are accessible via dot notation (`v.x`, `v.y`, `v.z`) or integer indexing (`v[1]`, `v[2]`, `v[3]`).
+"""
+struct VectorField{N, C <: Tuple}
+    components::C
+    VectorField{N}(components::C) where {N, C <: Tuple} = new{N, C}(components)
+end
+
+"""
+    struct TensorField{N, C <: Tuple}
+
+A symmetric tensor field for N-dimensional space.
+Components are accessible via dot notation (`t.xx`, `t.xy`, etc.) or
+two-index notation (`t[1,1]`, `t[1,2]`, etc., with symmetry: `t[i,j] == t[j,i]`).
+
+2D components (in order): `xx, yy, xy`
+3D components (in order): `xx, yy, zz, xy, xz, yz`
+"""
+struct TensorField{N, C <: Tuple}
+    components::C
+    TensorField{N}(components::C) where {N, C <: Tuple} = new{N, C}(components)
+end
+
+# --- VectorField accessors ---
+
+function Base.getproperty(v::VectorField, s::Symbol)
+    s === :components && return getfield(v, :components)
+    s === :x          && return getfield(v, :components)[1]
+    s === :y          && return getfield(v, :components)[2]
+    s === :z          && return getfield(v, :components)[3]
+    error("VectorField has no property $s")
+end
+
+Base.propertynames(::VectorField{1}) = (:x,)
+Base.propertynames(::VectorField{2}) = (:x, :y)
+Base.propertynames(::VectorField{3}) = (:x, :y, :z)
+
+Base.getindex(v::VectorField, i::Int) = getfield(v, :components)[i]
+
+Base.iterate(v::VectorField, state...) = iterate(getfield(v, :components), state...)
+Base.length(::VectorField{N}) where {N} = N
+
+# --- TensorField accessors ---
+
+function Base.getproperty(t::TensorField{N}, s::Symbol) where {N}
+    s === :components && return getfield(t, :components)
+    s === :xx         && return getfield(t, :components)[1]
+    s === :yy         && return getfield(t, :components)[2]
+    if N == 3
+        s === :zz && return getfield(t, :components)[3]
+        s === :xy && return getfield(t, :components)[4]
+        s === :xz && return getfield(t, :components)[5]
+        s === :yz && return getfield(t, :components)[6]
+    else
+        s === :xy && return getfield(t, :components)[3]
+    end
+    error("TensorField has no property $s")
+end
+
+Base.propertynames(::TensorField{2}) = (:xx, :yy, :xy)
+Base.propertynames(::TensorField{3}) = (:xx, :yy, :zz, :xy, :xz, :yz)
+
+function Base.getindex(t::TensorField{N}, i::Int, j::Int) where {N}
+    a, b = minmax(i, j)
+    if N == 2
+        a == 1 && b == 1 && return getfield(t, :components)[1]
+        a == 2 && b == 2 && return getfield(t, :components)[2]
+        a == 1 && b == 2 && return getfield(t, :components)[3]
+    else
+        a == 1 && b == 1 && return getfield(t, :components)[1]
+        a == 2 && b == 2 && return getfield(t, :components)[2]
+        a == 3 && b == 3 && return getfield(t, :components)[3]
+        a == 1 && b == 2 && return getfield(t, :components)[4]
+        a == 1 && b == 3 && return getfield(t, :components)[5]
+        a == 2 && b == 3 && return getfield(t, :components)[6]
+    end
+    error("invalid tensor index ($i, $j) for $(N)D TensorField")
+end
+
+Base.iterate(t::TensorField, state...) = iterate(getfield(t, :components), state...)
+Base.length(::TensorField{N}) where {N} = N == 2 ? 3 : 6
+
+# --- set! ---
+
+set!(v::VectorField, args...) = foreach(f -> set!(f, args...), getfield(v, :components))
+set!(t::TensorField, args...) = foreach(f -> set!(f, args...), getfield(t, :components))
+
+# --- GPU adaptation ---
+
+Adapt.adapt_structure(to, v::VectorField{N}) where {N} =
+    VectorField{N}(map(f -> Adapt.adapt(to, f), getfield(v, :components)))
+
+Adapt.adapt_structure(to, t::TensorField{N}) where {N} =
+    TensorField{N}(map(f -> Adapt.adapt(to, f), getfield(t, :components)))
+
+# --- factory functions ---
+
+"""
     VectorField(backend::Backend, grid::StructuredGrid{N}, args...; kwargs...) where {N}
 
-Create a vector field in the form of a `NamedTuple` on the given `grid` using the specified `backend`. With each component being a `Field`.
-
-## Arguments:
-- `backend::Backend`: The backend to be used for computation.
-- `grid::StructuredGrid{N}`: The structured grid defining the computational domain.
-- `args...`: Additional positional arguments to pass to the `Field` constructor.
-- `kwargs...`: Additional keyword arguments to pass to the `Field` constructor.
+Create a `VectorField` on the given `grid`. Each of the N components is a `Field` staggered
+at `Vertex()` along its own dimension and `Center()` along all others.
+Components are accessible as `v.x`/`v.y`/`v.z` or `v[1]`/`v[2]`/`v[3]`.
 """
 function VectorField(backend::Backend, grid::StructuredGrid{N}, args...; kwargs...) where {N}
-    coord_names = axes_names(grid)
-    names = ntuple(i -> coord_names[i], Val(N))
-    values = ntuple(Val(N)) do D
+    components = ntuple(Val(N)) do D
         Base.@_inline_meta
         Field(backend, grid, vector_location(Val(D), Val(N)), args...; kwargs...)
     end
-    return NamedTuple{names}(values)
+    return VectorField{N}(components)
 end
 
 """
     TensorField(backend::Backend, grid::StructuredGrid{2}, args...; kwargs...)
 
-Create a 2D tensor field in the form of a named tuple on the given `grid` using the specified `backend`, with components `xx`, `yy`, and `xy` each being a `Field`.
-
-## Arguments:
-- `backend::Backend`: The backend to be used for computation.
-- `grid::StructuredGrid{2}`: The 2D structured grid defining the computational domain.
-- `args...`: Additional positional arguments to pass to the `Field` constructor.
-- `kwargs...`: Additional keyword arguments to pass to the `Field` constructor.
+Create a 2D symmetric `TensorField`. Components `(xx, yy, xy)` are stored in order.
+Access via `t.xx`/`t.yy`/`t.xy` or `t[1,1]`/`t[2,2]`/`t[1,2]` (symmetric: `t[i,j] == t[j,i]`).
 """
 function TensorField(backend::Backend, grid::StructuredGrid{2}, args...; kwargs...)
-    (xx = Field(backend, grid, Center(), args...; kwargs...),
-     yy = Field(backend, grid, Center(), args...; kwargs...),
-     xy = Field(backend, grid, Vertex(), args...; kwargs...))
+    components = (
+        Field(backend, grid, Center(), args...; kwargs...),
+        Field(backend, grid, Center(), args...; kwargs...),
+        Field(backend, grid, Vertex(), args...; kwargs...),
+    )
+    return TensorField{2}(components)
 end
 
 """
     TensorField(backend::Backend, grid::StructuredGrid{3}, args...; kwargs...)
 
-Create a 3D tensor field in the form of a named tuple on the given `grid` using the specified `backend`, with components `xx`, `yy`, `zz`, `xy`, `xz`, and `yz` each being a `Field`.
-
-## Arguments:
-- `backend::Backend`: The backend to be used for computation.
-- `grid::StructuredGrid{3}`: The 3D structured grid defining the computational domain.
-- `args...`: Additional positional arguments to pass to the `Field` constructor.
-- `kwargs...`: Additional keyword arguments to pass to the `Field` constructor.
+Create a 3D symmetric `TensorField`. Components `(xx, yy, zz, xy, xz, yz)` are stored in order.
+Access via `t.xx` etc. or `t[1,1]`/`t[1,2]` etc. (symmetric: `t[i,j] == t[j,i]`).
 """
 function TensorField(backend::Backend, grid::StructuredGrid{3}, args...; kwargs...)
-    (xx = Field(backend, grid, Center(), args...; kwargs...),
-     yy = Field(backend, grid, Center(), args...; kwargs...),
-     zz = Field(backend, grid, Center(), args...; kwargs...),
-     xy = Field(backend, grid, (Vertex(), Vertex(), Center()), args...; kwargs...),
-     xz = Field(backend, grid, (Vertex(), Center(), Vertex()), args...; kwargs...),
-     yz = Field(backend, grid, (Center(), Vertex(), Vertex()), args...; kwargs...))
+    components = (
+        Field(backend, grid, Center(), args...; kwargs...),
+        Field(backend, grid, Center(), args...; kwargs...),
+        Field(backend, grid, Center(), args...; kwargs...),
+        Field(backend, grid, (Vertex(), Vertex(), Center()), args...; kwargs...),
+        Field(backend, grid, (Vertex(), Center(), Vertex()), args...; kwargs...),
+        Field(backend, grid, (Center(), Vertex(), Vertex()), args...; kwargs...),
+    )
+    return TensorField{3}(components)
 end
 
 VectorField(arch::Architecture, args...; kwargs...) = VectorField(Architectures.get_backend(arch), args...; kwargs...)

--- a/src/GridOperators/cartesian_field_operators.jl
+++ b/src/GridOperators/cartesian_field_operators.jl
@@ -1,66 +1,68 @@
-for (dim, coord) in enumerate((:x, :y, :z))
-    _l = Symbol(:left, coord)
-    _r = Symbol(:right, coord)
-    _δ = Symbol(:δ, coord)
-    _∂ = Symbol(:∂, coord)
-    _∂² = Symbol(:∂², coord)
-    _∂k∂ = Symbol(:∂k∂, coord)
+for coords in ((:x, :y, :z), (:1, :2, :3))
+    for (dim, coord) in enumerate(coords)
+        _l = Symbol(:left, coord)
+        _r = Symbol(:right, coord)
+        _δ = Symbol(:δ, coord)
+        _∂ = Symbol(:∂, coord)
+        _∂² = Symbol(:∂², coord)
+        _∂k∂ = Symbol(:∂k∂, coord)
 
-    @eval begin
-        export $_δ, $_∂, $_∂², $_∂k∂, $_l, $_r
+        @eval begin
+            export $_δ, $_∂, $_∂², $_∂k∂, $_l, $_r
 
-        """
-            $($_l)(f, I)
+            """
+                $($_l)(f, I)
 
-        "left side" of a field (`[1:end-1]`) in $($(string(coord))) direction.
-        """
-        @add_cartesian function $_l(f::AbstractField, I::Vararg{Integer,N}) where {N}
-            left(f, Dim($dim), I...)
-        end
+            "left side" of a field (`[1:end-1]`) in $($(string(coord))) direction.
+            """
+            @add_cartesian function $_l(f::AbstractField, I::Vararg{Integer,N}) where {N}
+                left(f, Dim($dim), I...)
+            end
 
-        """
-            $($_r)(f, I)
+            """
+                $($_r)(f, I)
 
-        "right side" of a field (`[2:end]`) in $($(string(coord))) direction.
-        """
-        @add_cartesian function $_r(f::AbstractField, I::Vararg{Integer,N}) where {N}
-            right(f, Dim($dim), I...)
-        end
+            "right side" of a field (`[2:end]`) in $($(string(coord))) direction.
+            """
+            @add_cartesian function $_r(f::AbstractField, I::Vararg{Integer,N}) where {N}
+                right(f, Dim($dim), I...)
+            end
 
-        """
-            $($_δ)(f, I)
+            """
+                $($_δ)(f, I)
 
-        Finite difference in $($(string(coord))) direction.
-        """
-        @add_cartesian function $_δ(f::AbstractField, I::Vararg{Integer,N}) where {N}
-            δ(f, Dim($dim), I...)
-        end
+            Finite difference in $($(string(coord))) direction.
+            """
+            @add_cartesian function $_δ(f::AbstractField, I::Vararg{Integer,N}) where {N}
+                δ(f, Dim($dim), I...)
+            end
 
-        """
-            $($_∂)(f, grid, I)
+            """
+                $($_∂)(f, grid, I)
 
-        Directional partial derivative in $($(string(coord))) direction.
-        """
-        @add_cartesian function $_∂(f::AbstractField, grid, I::Vararg{Integer,N}) where {N}
-            ∂(f, grid, Dim($dim), I...)
-        end
+            Directional partial derivative in $($(string(coord))) direction.
+            """
+            @add_cartesian function $_∂(f::AbstractField, grid, I::Vararg{Integer,N}) where {N}
+                ∂(f, grid, Dim($dim), I...)
+            end
 
-        """
-            $($_∂²)(f, grid, I)
+            """
+                $($_∂²)(f, grid, I)
 
-        Directional partial second derivative in $($(string(coord))) direction.
-        """
-        @add_cartesian function $_∂²(f::AbstractField, grid, I::Vararg{Integer,N}) where {N}
-            ∂²(f, grid, Dim($dim), I...)
-        end
+            Directional partial second derivative in $($(string(coord))) direction.
+            """
+            @add_cartesian function $_∂²(f::AbstractField, grid, I::Vararg{Integer,N}) where {N}
+                ∂²(f, grid, Dim($dim), I...)
+            end
 
-        """
-            $($_∂k∂)(f, k, grid, I)
+            """
+                $($_∂k∂)(f, k, grid, I)
 
-        Directional divergence of gradient times coefficient `k` in $($(string(coord))) direction.
-        """
-        @add_cartesian function $_∂k∂(f::AbstractField, k::AbstractField, grid, I::Vararg{Integer,N}) where {N}
-            ∂k∂(f, k, grid, Dim($dim), I...)
+            Directional divergence of gradient times coefficient `k` in $($(string(coord))) direction.
+            """
+            @add_cartesian function $_∂k∂(f::AbstractField, k::AbstractField, grid, I::Vararg{Integer,N}) where {N}
+                ∂k∂(f, k, grid, Dim($dim), I...)
+            end
         end
     end
 end

--- a/src/GridOperators/field_operators.jl
+++ b/src/GridOperators/field_operators.jl
@@ -58,6 +58,17 @@ end
     return divg(V, grid, Tuple(I)...)
 end
 
+@propagate_inbounds @generated function divg(V::VectorField{N}, grid::StructuredGrid{N}, I::Vararg{Integer,N}) where {N}
+    quote
+        @inline
+        Base.Cartesian.@ncall $N (+) D -> ∂(V[D], grid, Dim(D), I...)
+    end
+end
+
+@propagate_inbounds function divg(V::VectorField{N}, grid::StructuredGrid{N}, I::CartesianIndex{N}) where {N}
+    return divg(V, grid, Tuple(I)...)
+end
+
 """
     lapl(F, grid, I...)
 
@@ -121,5 +132,16 @@ Compute the magnitude of a vector field `V` at a given grid location `I` in a st
 end
 
 @propagate_inbounds function vmag(V::NamedTuple{names,<:NTuple{N,AbstractField}}, grid::StructuredGrid{N}, I::CartesianIndex{N}) where {names,N}
+    return vmag(V, grid, Tuple(I)...)
+end
+
+@propagate_inbounds @generated function vmag(V::VectorField{N}, grid::StructuredGrid{N}, I::Vararg{Integer,N}) where {N}
+    quote
+        @inline
+        sqrt(Base.Cartesian.@ncall $N (+) D -> lerp(V[D], Center(), grid, I...)^2)
+    end
+end
+
+@propagate_inbounds function vmag(V::VectorField{N}, grid::StructuredGrid{N}, I::CartesianIndex{N}) where {N}
     return vmag(V, grid, Tuple(I)...)
 end

--- a/src/GridOperators/masked_cartesian_field_operators.jl
+++ b/src/GridOperators/masked_cartesian_field_operators.jl
@@ -1,66 +1,68 @@
-for (dim, coord) in enumerate((:x, :y, :z))
-    _l = Symbol(:left, coord)
-    _r = Symbol(:right, coord)
-    _δ = Symbol(:δ, coord)
-    _∂ = Symbol(:∂, coord)
-    _∂² = Symbol(:∂², coord)
-    _∂k∂ = Symbol(:∂k∂, coord)
+for coords in ((:x, :y, :z), (:1, :2, :3))
+    for (dim, coord) in enumerate(coords)
+        _l = Symbol(:left, coord)
+        _r = Symbol(:right, coord)
+        _δ = Symbol(:δ, coord)
+        _∂ = Symbol(:∂, coord)
+        _∂² = Symbol(:∂², coord)
+        _∂k∂ = Symbol(:∂k∂, coord)
 
-    @eval begin
-        export $_δ, $_∂, $_∂², $_∂k∂, $_l, $_r
+        @eval begin
+            export $_δ, $_∂, $_∂², $_∂k∂, $_l, $_r
 
-        """
-            $($_l)(f, ω, I)
+            """
+                $($_l)(f, ω, I)
 
-        "left side" of a field (`[1:end-1]`) in $($(string(coord))) direction, masked with `ω`.
-        """
-        @add_cartesian function $_l(f::AbstractField, ω::AbstractMask, I::Vararg{Integer,N}) where {N}
-            left(f, ω, Dim($dim), I...)
-        end
+            "left side" of a field (`[1:end-1]`) in $($(string(coord))) direction, masked with `ω`.
+            """
+            @add_cartesian function $_l(f::AbstractField, ω::AbstractMask, I::Vararg{Integer,N}) where {N}
+                left(f, ω, Dim($dim), I...)
+            end
 
-        """
-            $($_r)(f, ω, I)
+            """
+                $($_r)(f, ω, I)
 
-        "right side" of a field (`[2:end]`) in $($(string(coord))) direction, masked with `ω`.
-        """
-        @add_cartesian function $_r(f::AbstractField, ω::AbstractMask, I::Vararg{Integer,N}) where {N}
-            right(f, ω, Dim($dim), I...)
-        end
+            "right side" of a field (`[2:end]`) in $($(string(coord))) direction, masked with `ω`.
+            """
+            @add_cartesian function $_r(f::AbstractField, ω::AbstractMask, I::Vararg{Integer,N}) where {N}
+                right(f, ω, Dim($dim), I...)
+            end
 
-        """
-            $($_δ)(f, ω, I)
+            """
+                $($_δ)(f, ω, I)
 
-        Finite difference in $($(string(coord))) direction, masked with `ω`.
-        """
-        @add_cartesian function $_δ(f::AbstractField, ω::AbstractMask, I::Vararg{Integer,N}) where {N}
-            δ(f, ω, Dim($dim), I...)
-        end
+            Finite difference in $($(string(coord))) direction, masked with `ω`.
+            """
+            @add_cartesian function $_δ(f::AbstractField, ω::AbstractMask, I::Vararg{Integer,N}) where {N}
+                δ(f, ω, Dim($dim), I...)
+            end
 
-        """
-            $($_∂)(f, ω, grid, I)
+            """
+                $($_∂)(f, ω, grid, I)
 
-        Directional partial derivative in $($(string(coord))) direction, masked with `ω`.
-        """
-        @add_cartesian function $_∂(f::AbstractField, ω::AbstractMask, grid, I::Vararg{Integer,N}) where {N}
-            ∂(f, ω, grid, Dim($dim), I...)
-        end
+            Directional partial derivative in $($(string(coord))) direction, masked with `ω`.
+            """
+            @add_cartesian function $_∂(f::AbstractField, ω::AbstractMask, grid, I::Vararg{Integer,N}) where {N}
+                ∂(f, ω, grid, Dim($dim), I...)
+            end
 
-        """
-        $($_∂²)(f, ω, grid, I)
+            """
+            $($_∂²)(f, ω, grid, I)
 
-        Directional partial second derivative in $($(string(coord))) direction, masked with `ω`.
-        """
-        @add_cartesian function $_∂²(f::AbstractField, ω::AbstractMask, grid, I::Vararg{Integer,N}) where {N}
-            ∂²(f, ω, grid, Dim($dim), I...)
-        end
+            Directional partial second derivative in $($(string(coord))) direction, masked with `ω`.
+            """
+            @add_cartesian function $_∂²(f::AbstractField, ω::AbstractMask, grid, I::Vararg{Integer,N}) where {N}
+                ∂²(f, ω, grid, Dim($dim), I...)
+            end
 
-        """
-        $($_∂k∂)(f, k, ω, grid, I)
+            """
+            $($_∂k∂)(f, k, ω, grid, I)
 
-        Directional divergence of gradient times coefficient `k` in $($(string(coord))) direction, masked with `ω`.
-        """
-        @add_cartesian function $_∂k∂(f::AbstractField, k::AbstractField, ω::AbstractMask, grid, I::Vararg{Integer,N}) where {N}
-            ∂k∂(f, k, ω, grid, Dim($dim), I...)
+            Directional divergence of gradient times coefficient `k` in $($(string(coord))) direction, masked with `ω`.
+            """
+            @add_cartesian function $_∂k∂(f::AbstractField, k::AbstractField, ω::AbstractMask, grid, I::Vararg{Integer,N}) where {N}
+                ∂k∂(f, k, ω, grid, Dim($dim), I...)
+            end
         end
     end
 end

--- a/src/GridOperators/masked_field_operators.jl
+++ b/src/GridOperators/masked_field_operators.jl
@@ -65,6 +65,23 @@ end
     return divg(V, ω, grid, Tuple(I)...)
 end
 
+@propagate_inbounds @generated function divg(V::VectorField{N},
+                                             ω::AbstractMask{T,N},
+                                             grid::StructuredGrid{N},
+                                             I::Vararg{Integer,N}) where {N,T}
+    quote
+        @inline
+        Base.Cartesian.@ncall $N (+) D -> ∂(V[D], ω, grid, Dim(D), I...)
+    end
+end
+
+@propagate_inbounds function divg(V::VectorField{N},
+                                  ω::AbstractMask{T,N},
+                                  grid::StructuredGrid{N},
+                                  I::CartesianIndex{N}) where {N,T}
+    return divg(V, ω, grid, Tuple(I)...)
+end
+
 """
     lapl(F, ω, grid, I...)
 

--- a/test/test_fields.jl
+++ b/test/test_fields.jl
@@ -53,6 +53,24 @@ for backend in TEST_BACKENDS, T in TEST_TYPES
                                                 0.0; 0.0;; 1.0; 1.0;; 2.0; 2.0]
             end
         end
+        @testset "VectorField indexing" begin
+            V = VectorField(backend, grid)
+            @test V[1] === V.x
+            @test V[2] === V.y
+            @test V[3] === V.z
+        end
+        @testset "TensorField indexing" begin
+            τ = TensorField(backend, grid)
+            @test τ[1, 1] === τ.xx
+            @test τ[2, 2] === τ.yy
+            @test τ[3, 3] === τ.zz
+            @test τ[1, 2] === τ.xy
+            @test τ[1, 3] === τ.xz
+            @test τ[2, 3] === τ.yz
+            @test τ[2, 1] === τ.xy  # symmetry
+            @test τ[3, 1] === τ.xz
+            @test τ[3, 2] === τ.yz
+        end
         @testset "constant field" begin
             @testset "zero" begin
                 field = ZeroField{Float64}()

--- a/test/test_grid_operators.jl
+++ b/test/test_grid_operators.jl
@@ -111,6 +111,38 @@ for backend in TEST_BACKENDS, T in TEST_TYPES
             end
         end
 
+        @testset "tensor notation (∂1==∂x, ∂2==∂y, ∂3==∂z)" begin
+            Ci    = Field(backend, grid, Center())
+            V_xyz = VectorField(backend, grid)
+            V_num = VectorField(backend, grid)
+
+            set!(Ci, grid, (x, y, z) -> exp(-x^2 - y^2 - z^2))
+
+            @kernel function partial_xyz!(V, F, g::StructuredGrid, O)
+                I = @index(Global, NTuple)
+                I = I + O
+                V.x[I...] = ∂x(F, g, I...)
+                V.y[I...] = ∂y(F, g, I...)
+                V.z[I...] = ∂z(F, g, I...)
+            end
+
+            @kernel function partial_num!(V, F, g::StructuredGrid, O)
+                I = @index(Global, NTuple)
+                I = I + O
+                V.x[I...] = ∂1(F, g, I...)
+                V.y[I...] = ∂2(F, g, I...)
+                V.z[I...] = ∂3(F, g, I...)
+            end
+
+            launch(arch, grid, partial_xyz! => (V_xyz, Ci, grid))
+            launch(arch, grid, partial_num! => (V_num, Ci, grid))
+
+            KernelAbstractions.synchronize(backend)
+            @test interior(V_xyz.x) == interior(V_num.x)
+            @test interior(V_xyz.y) == interior(V_num.y)
+            @test interior(V_xyz.z) == interior(V_num.z)
+        end
+
         @testset "vmag" begin
             V  = VectorField(backend, grid)
             C1 = Field(backend, grid, Center())


### PR DESCRIPTION
Hey, first of all, thanks for the amazing package!

I know that there is a big rewrite coming, but I would like to make a few changes regardless that do not change the current API but give it a bit more flexibility.

First of all, I noticed that the helper functions for the grid operations are `∂x, ∂y, and ∂z`. However, that does not bode nicely to use cases where the user might want to represent its equation in tensor notation, calling the dimensions then 1, 2 and 3 to match the indexes in the expression of the PDE.

This PR adds the functionality to use `∂1, ∂2 and ∂3`, along with the other helpers. Additionally, I added new types VectorField and TensorField while keeping the `tensor.xx` or `vector.x` notation intact, but adding the possibility of using array indexing `tensor[1, 1]` and `vector[1]`.

I know it might be asking a lot, but on top of this PR, is it possible that the new rewrite #103  takes this use case into account? Otherwise I can just come back later after the rewrite and reimplement it in a non-disruptive way.